### PR TITLE
build: Adapt Buck2 definitions for target 'crates_pro'

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1,44 +1,11 @@
-load("@prelude//rust:cargo_package.bzl", "cargo")
-
-# package definitions
-filegroup(
-    name = "crates_pro-0.1.0.crate",
-    srcs = [
-        "src/cli.rs",
-        "src/core_controller.rs",
-        "src/main.rs",
-    ],
-)
-
-pkg_deps = [
-    "//project/crates-pro:analysis",
-    "//project/crates-pro:data_transporter",
-    "//project/crates-pro:model",
-    "//project/crates-pro:repo_import",
-    "//project/crates-pro:search",
-    "//project/crates-pro:tudriver",
-    "//third-party:dotenvy",
-    "//third-party:neo4rs",
-    "//third-party:rdkafka",
-    "//third-party:serde_json",
-    "//third-party:structopt",
-    "//third-party:tokio",
-    "//third-party:tracing",
-    "//third-party:tracing-subscriber",
-    "//third-party:serial_test"
-]
-
-# targets
-cargo.rust_binary(
+# binaries
+alias(
     name = "crates_pro",
-    srcs = [":crates_pro-0.1.0.crate"],
-    crate_root = "crates_pro-0.1.0.crate/src/main.rs",
-    edition = "2021",
-    deps = pkg_deps,
+    actual = "//project/crates-pro/crates_pro:crates_pro",
     visibility = ["PUBLIC"],
 )
 
-# aliases
+# libraries
 alias(
     name = "analysis",
     actual = "//project/crates-pro/analysis:analysis",
@@ -63,14 +30,14 @@ alias(
     visibility = ["PUBLIC"],
 )
 
+alias(
+    name = "search",
+    actual = "//project/crates-pro/search:search",
+    visibility = ["PUBLIC"],
+)
 
 alias(
     name = "tudriver",
     actual = "//project/crates-pro/tudriver:tudriver",
-    visibility = ["PUBLIC"],
-)
-alias(
-    name = "search",
-    actual = "//project/crates-pro/search:search",
     visibility = ["PUBLIC"],
 )

--- a/crates_pro/BUCK
+++ b/crates_pro/BUCK
@@ -1,0 +1,37 @@
+load("@prelude//rust:cargo_package.bzl", "cargo")
+
+filegroup(
+    name = "crates_pro-0.1.0.crate",
+    srcs = [
+        "src/cli.rs",
+        "src/core_controller.rs",
+        "src/main.rs",
+    ],
+)
+
+pkg_deps = [
+    "//project/crates-pro:analysis",
+    "//project/crates-pro:data_transporter",
+    "//project/crates-pro:model",
+    "//project/crates-pro:repo_import",
+    "//project/crates-pro:search",
+    "//project/crates-pro:tudriver",
+    "//third-party:dotenvy",
+    "//third-party:neo4rs",
+    "//third-party:rdkafka",
+    "//third-party:serde_json",
+    "//third-party:serial_test",
+    "//third-party:structopt",
+    "//third-party:tokio",
+    "//third-party:tracing",
+    "//third-party:tracing-subscriber"
+]
+
+cargo.rust_binary(
+    name = "crates_pro",
+    srcs = [":crates_pro-0.1.0.crate"],
+    crate_root = "crates_pro-0.1.0.crate/src/main.rs",
+    edition = "2021",
+    deps = pkg_deps,
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
* Move Buck2 definitions for binary target 'crates_pro' to crates_pro/BUCK
* Create an alias for 'crates_pro' in (root)/BUCK