### PR TITLE
Fix deployment script, add sensleak-worker target, use 2024 edition

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,12 @@
 # Use the TuGraph compile environment as the base image, specifically 'tugraph/tugraph-compile-centos8', to avoid
 # compatibility issues. It has a newer version of GLIBC (2.28) than 'tugraph/tugraph-compile-ubuntu18.04' (2.27).
-FROM tugraph/tugraph-compile-centos8:1.3.4
+FROM tugraph/tugraph-compile-centos8:1.3.5
 
 # Install dependencies
 RUN dnf update -y \
     && dnf group install -y "Development Tools" \
     && dnf install -y glibc-langpack-en sudo tzdata
-RUN dnf install -y clang cmake curl git net-tools tree
+RUN dnf install -y clang cmake curl cyrus-sasl-devel git net-tools tree
 
 # Install Docker
 ARG DOCKER_GID
@@ -29,9 +29,13 @@ RUN useradd -m -s /bin/bash -u $USER_UID $USERNAME \
     && usermod -aG docker $USERNAME
 USER $USERNAME
 
-# Install Rust, set environment variable
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# Install Rust with nightly-2025-01-15 toolchain (as in NativeLink `MODULE.bazel`), set environment variable
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-2025-01-15 -y
 ENV PATH="/home/$USERNAME/.cargo/bin:${PATH}"
+
+# Install Buck2
+RUN rustup install nightly-2024-11-22 \
+    && cargo +nightly-2024-11-22 install --git https://github.com/facebook/buck2.git --rev f1b6518 buck2
 
 # Create and set permissions for workspace directory
 USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
     "workspaceFolder": "/workspace",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "mounts": [
-        "source=/home/rust/workspace/crates-pro-infra,target=/home/rust/workspace/crates-pro-infra,type=bind",
+        "source=/home/rust/workspace/crates-pro-infra,target=/var/crates-pro-infra,type=bind",
+        "source=${localWorkspaceFolder},target=/var/crates-pro-infra/project/crates-pro,type=bind",
         // Add mounts for snapshot taking
         "source=/home/rust/src/crates-pro-control,target=/home/rust/src/crates-pro-control,type=bind",
         "source=/mnt/devops/snapshots,target=/mnt/devops/snapshots,type=bind",

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Cargo.lock
 
 # Mac
 .DS_Store
+
+# Temp files for Docker image creation
+/build/

--- a/analysis/BUCK
+++ b/analysis/BUCK
@@ -29,7 +29,7 @@ cargo.rust_library(
     name = "analysis",
     srcs = [":analysis-0.1.0.crate"],
     crate_root = "analysis-0.1.0.crate/src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = pkg_deps,
     visibility = ["PUBLIC"],
 )
@@ -38,7 +38,7 @@ cargo.rust_binary(
     name = "sensleak_worker",
     srcs = [":analysis-0.1.0.crate"],
     crate_root = "analysis-0.1.0.crate/sensleak_worker/main.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [":analysis"] + pkg_deps,
     visibility = ["PUBLIC"],
 )

--- a/analysis/BUCK
+++ b/analysis/BUCK
@@ -1,22 +1,44 @@
-rust_library(
-    name = "analysis",
+load("@prelude//rust:cargo_package.bzl", "cargo")
+
+filegroup(
+    name = "analysis-0.1.0.crate",
     srcs = [
+        ### Library source
         "src/lib.rs",
         "src/kafka_handler.rs",
-        "src/utils.rs"
+        "src/utils.rs",
+        ### Workers source
+        "sensleak_worker/main.rs",
     ],
-    crate_root = "src/lib.rs",
+)
+
+pkg_deps = [
+    "//project/crates-pro:data_transporter",
+    "//project/crates-pro:model",
+    "//third-party:rdkafka",
+    "//third-party:serde",
+    "//third-party:serde_json",
+    "//third-party:tempfile",
+    "//third-party:tokio",
+    "//third-party:tokio-postgres",
+    "//third-party:tracing",
+    "//third-party:url",
+]
+
+cargo.rust_library(
+    name = "analysis",
+    srcs = [":analysis-0.1.0.crate"],
+    crate_root = "analysis-0.1.0.crate/src/lib.rs",
     edition = "2021",
-    deps = [
-        "//project/crates-pro:model",
-        "//third-party:rdkafka",
-        "//third-party:serde",
-        "//third-party:serde_json",
-        "//third-party:tempfile",
-        "//third-party:tokio",
-        "//third-party:tracing",
-        "//third-party:url",
-        
-    ],
+    deps = pkg_deps,
+    visibility = ["PUBLIC"],
+)
+
+cargo.rust_binary(
+    name = "sensleak_worker",
+    srcs = [":analysis-0.1.0.crate"],
+    crate_root = "analysis-0.1.0.crate/sensleak_worker/main.rs",
+    edition = "2021",
+    deps = [":analysis"] + pkg_deps,
     visibility = ["PUBLIC"],
 )

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+data_transporter = { workspace = true }
 model = { workspace = true }
 
 # third-party
@@ -11,6 +12,7 @@ rdkafka = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-postgres = { workspace = true, features = ["with-chrono-0_4"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "analysis"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 data_transporter = { workspace = true }

--- a/analysis/sensleak_worker/main.rs
+++ b/analysis/sensleak_worker/main.rs
@@ -1,0 +1,10 @@
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    println!("Starting the program. Press Ctrl+C to stop.");
+    loop {
+        println!("sensleak_worker");
+        thread::sleep(Duration::from_secs(1));
+    }
+}

--- a/crates_pro/BUCK
+++ b/crates_pro/BUCK
@@ -35,7 +35,7 @@ cargo.rust_binary(
     name = "crates_pro",
     srcs = [":crates_pro-0.1.0.crate"],
     crate_root = "crates_pro-0.1.0.crate/src/main.rs",
-    edition = "2021",
+    edition = "2024",
     deps = pkg_deps,
     visibility = ["PUBLIC"],
 )
@@ -44,7 +44,7 @@ cargo.rust_binary(
     name = "bin_analyze",
     srcs = [":crates_pro-0.1.0.crate"],
     crate_root = "crates_pro-0.1.0.crate/src/bin/bin_analyze.rs",
-    edition = "2021",
+    edition = "2024",
     deps = pkg_deps,
     visibility = ["PUBLIC"],
 )
@@ -53,7 +53,7 @@ cargo.rust_binary(
     name = "bin_data_transport",
     srcs = [":crates_pro-0.1.0.crate"],
     crate_root = "crates_pro-0.1.0.crate/src/bin/bin_data_transport.rs",
-    edition = "2021",
+    edition = "2024",
     deps = pkg_deps,
     visibility = ["PUBLIC"],
 )
@@ -62,7 +62,7 @@ cargo.rust_binary(
     name = "bin_repo_import",
     srcs = [":crates_pro-0.1.0.crate"],
     crate_root = "crates_pro-0.1.0.crate/src/bin/bin_repo_import.rs",
-    edition = "2021",
+    edition = "2024",
     deps = pkg_deps,
     visibility = ["PUBLIC"],
 )

--- a/crates_pro/Cargo.toml
+++ b/crates_pro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crates_pro"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 default-run = "crates_pro"
 
 [[bin]]

--- a/data_transporter/BUCK
+++ b/data_transporter/BUCK
@@ -9,7 +9,7 @@ rust_library(
         "src/transporter.rs",
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//project/crates-pro:model",
         "//project/crates-pro:repo_import",

--- a/data_transporter/Cargo.toml
+++ b/data_transporter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "data_transporter"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 model = { workspace = true }

--- a/deploy-crates-pro.sh
+++ b/deploy-crates-pro.sh
@@ -2,8 +2,7 @@
 set -euxo pipefail
 
 # source
-INFRA_PATH=/home/rust/workspace/crates-pro-infra
-LATEST_SRC_PATH=.
+INFRA_PATH=/var/crates-pro-infra
 # deployment
 NAMESPACE=crates-pro
 INSTANCE=test1
@@ -11,52 +10,38 @@ DEPLOYMENT=cratespro-backend-$INSTANCE
 KAFKA_HOST=172.17.0.1:30092
 TAKE_SNAPSHOT_BEFORE_REDEPLOY=0
 # build
+BUILD_DIR=/workspace/build
+IMAGES_DIR=/workspace/images
 TIMESTAMP=$(date +%Y%m%d-%H%M)
-STAGE1_IMAGE=crates-pro-infra:base-$TIMESTAMP
-STAGE2_IMAGE=crates-pro-infra:override-crates-pro-$TIMESTAMP
 CRATESPRO_MAIN_IMAGE=localhost:30500/crates-pro:local-$TIMESTAMP
 CRATESPRO_ANALYZE_IMAGE=localhost:30500/crates-pro-analyze:local-$TIMESTAMP
 CRATESPRO_DATA_TRANSPORT_IMAGE=localhost:30500/crates-pro-data-transport:local-$TIMESTAMP
 CRATESPRO_REPO_IMPORT_IMAGE=localhost:30500/crates-pro-repo-import:local-$TIMESTAMP
 
-docker build -t $STAGE1_IMAGE \
-    -f $INFRA_PATH/images/base.Dockerfile \
-    $INFRA_PATH
-docker build -t $STAGE2_IMAGE \
-    -f $INFRA_PATH/images/override-crates-pro.Dockerfile \
-    --build-arg BASE_IMAGE=$STAGE1_IMAGE \
-    $LATEST_SRC_PATH
-docker image rm $STAGE1_IMAGE
-docker build --target crates_pro -t $CRATESPRO_MAIN_IMAGE \
-    -f $LATEST_SRC_PATH/images/crates-pro.Dockerfile \
-    --build-arg BASE_IMAGE=$STAGE2_IMAGE \
-    --build-arg http_proxy --build-arg https_proxy \
-    --ulimit nofile=65535:65535 \
-    $LATEST_SRC_PATH
-docker build --target analyze -t $CRATESPRO_ANALYZE_IMAGE \
-    -f $LATEST_SRC_PATH/images/crates-pro.Dockerfile \
-    --build-arg BASE_IMAGE=$STAGE2_IMAGE \
-    --build-arg http_proxy --build-arg https_proxy \
-    --ulimit nofile=65535:65535 \
-    $LATEST_SRC_PATH
-docker build --target data_transport -t $CRATESPRO_DATA_TRANSPORT_IMAGE \
-    -f $LATEST_SRC_PATH/images/crates-pro.Dockerfile \
-    --build-arg BASE_IMAGE=$STAGE2_IMAGE \
-    --build-arg http_proxy --build-arg https_proxy \
-    --ulimit nofile=65535:65535 \
-    $LATEST_SRC_PATH
-docker build --target repo_import -t $CRATESPRO_REPO_IMPORT_IMAGE \
-    -f $LATEST_SRC_PATH/images/crates-pro.Dockerfile \
-    --build-arg BASE_IMAGE=$STAGE2_IMAGE \
-    --build-arg http_proxy --build-arg https_proxy \
-    --ulimit nofile=65535:65535 \
-    $LATEST_SRC_PATH
-docker image rm $STAGE2_IMAGE
+### Step 1: Compile, then copy artifacts to $BUILD_DIR
+mkdir -p $BUILD_DIR
+rm -rf $BUILD_DIR/*
+cd $INFRA_PATH
+cp "$(buck2 build //project/crates-pro:crates_pro --show-simple-output)" $BUILD_DIR/crates_pro
+cp "$(buck2 build //project/crates-pro:bin_analyze --show-simple-output)" $BUILD_DIR/bin_analyze
+cp "$(buck2 build //project/crates-pro:bin_data_transport --show-simple-output)" $BUILD_DIR/bin_data_transport
+cp "$(buck2 build //project/crates-pro:bin_repo_import --show-simple-output)" $BUILD_DIR/bin_repo_import
+cp /workspace/.env $BUILD_DIR/.env
+cd /workspace
+
+### Step 2: Build Docker images
+docker build --target crates_pro        -t $CRATESPRO_MAIN_IMAGE            -f $IMAGES_DIR/crates-pro.Dockerfile    $BUILD_DIR
+docker build --target analyze           -t $CRATESPRO_ANALYZE_IMAGE         -f $IMAGES_DIR/crates-pro.Dockerfile    $BUILD_DIR
+docker build --target data_transport    -t $CRATESPRO_DATA_TRANSPORT_IMAGE  -f $IMAGES_DIR/crates-pro.Dockerfile    $BUILD_DIR
+docker build --target repo_import       -t $CRATESPRO_REPO_IMPORT_IMAGE     -f $IMAGES_DIR/crates-pro.Dockerfile    $BUILD_DIR
+
+### Step 3: Push Docker images
 docker push $CRATESPRO_MAIN_IMAGE
 docker push $CRATESPRO_ANALYZE_IMAGE
 docker push $CRATESPRO_DATA_TRANSPORT_IMAGE
 docker push $CRATESPRO_REPO_IMPORT_IMAGE
 
+### Step 4: Stop current containers
 # Scale deployment to 0 replicas
 kubectl scale deployment $DEPLOYMENT -n $NAMESPACE --replicas=0
 
@@ -70,7 +55,7 @@ if [ "$TAKE_SNAPSHOT_BEFORE_REDEPLOY" -eq 1 ] || [ "$INSTANCE" = "main" ]; then
     /home/rust/src/crates-pro-control/cpctl-snapshot $INSTANCE
 fi
 
-# Set new images
+### Step 5: Set new images
 kubectl set image deployment/$DEPLOYMENT -n $NAMESPACE crates-pro=$CRATESPRO_MAIN_IMAGE
 kubectl set image deployment/$DEPLOYMENT -n $NAMESPACE analyze=$CRATESPRO_ANALYZE_IMAGE
 kubectl set image deployment/$DEPLOYMENT -n $NAMESPACE data-transport=$CRATESPRO_DATA_TRANSPORT_IMAGE
@@ -82,5 +67,6 @@ while docker run --rm -t bitnami/kafka -- kafka-consumer-groups.sh --bootstrap-s
     sleep 5
 done
 
+### Step 6: Run new containers
 # Scale deployment back to 1 replica
 kubectl scale deployment $DEPLOYMENT -n $NAMESPACE --replicas=1

--- a/deploy-sensleak-worker.sh
+++ b/deploy-sensleak-worker.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euxo pipefail
+
+# source
+INFRA_PATH=/var/crates-pro-infra
+# deployment
+NAMESPACE=sensleak-worker
+DEPLOYMENT=sensleak-worker
+KAFKA_HOST=172.17.0.1:30092
+# build
+BUILD_DIR=/workspace/build
+IMAGES_DIR=/workspace/images
+TIMESTAMP=$(date +%Y%m%d-%H%M)
+SENSLEAK_WORKER_IMAGE=localhost:30500/sensleak-worker:local-$TIMESTAMP
+
+### Step 1: Compile, then copy artifacts to $BUILD_DIR
+mkdir -p $BUILD_DIR
+rm -rf $BUILD_DIR/*
+cd $INFRA_PATH
+cp "$(buck2 build //project/crates-pro/analysis:sensleak_worker --show-simple-output)" $BUILD_DIR/sensleak_worker
+cp "$(buck2 build //project/sensleak-rs:scan --show-simple-output)" $BUILD_DIR/scan
+cp /workspace/.env $BUILD_DIR/.env
+cd /workspace
+
+### Step 2: Build Docker images
+docker build -t $SENSLEAK_WORKER_IMAGE -f $IMAGES_DIR/sensleak-worker.Dockerfile $BUILD_DIR
+
+### Step 3: Push Docker images
+docker push $SENSLEAK_WORKER_IMAGE
+
+### Step 4: Stop current containers
+# Scale deployment to 0 replicas
+kubectl scale deployment $DEPLOYMENT -n $NAMESPACE --replicas=0
+
+# Wait until all pods are terminated
+while kubectl get pods -n $NAMESPACE | grep $DEPLOYMENT > /dev/null; do
+    sleep 5
+done
+
+### Step 5: Set new images
+kubectl set image deployment/$DEPLOYMENT -n $NAMESPACE sensleak-worker=$SENSLEAK_WORKER_IMAGE
+
+# Wait until all kafka consumers are removed
+CONSUMER_GROUP=sensleak-worker-1-group
+while docker run --rm -t bitnami/kafka -- kafka-consumer-groups.sh --bootstrap-server $KAFKA_HOST --group $CONSUMER_GROUP --describe | grep rdkafka > /dev/null; do
+    sleep 5
+done
+
+### Step 6: Run new containers
+# Scale deployment back to 1 replica
+kubectl scale deployment $DEPLOYMENT -n $NAMESPACE --replicas=1

--- a/images/crates-pro.Dockerfile
+++ b/images/crates-pro.Dockerfile
@@ -1,15 +1,3 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE AS builder
-
-RUN buck2 clean
-RUN mkdir -p /build
-
-RUN cp "$(buck2 build //project/crates-pro:crates_pro --show-simple-output)" /build/crates_pro \
-    && cp "$(buck2 build //project/crates-pro:bin_analyze --show-simple-output)" /build/bin_analyze \
-    && cp "$(buck2 build //project/crates-pro:bin_data_transport --show-simple-output)" /build/bin_data_transport \
-    && cp "$(buck2 build //project/crates-pro:bin_repo_import --show-simple-output)" /build/bin_repo_import
-RUN cp /workdir/project/crates-pro/.env /build/.env
-
 FROM almalinux:8.10-20250307 AS base
 
 # Install tools and dependencies
@@ -35,31 +23,30 @@ RUN curl -L -o swagger-ui-5.17.14.zip https://github.com/swagger-api/swagger-ui/
     && unzip -j swagger-ui-5.17.14.zip "swagger-ui-5.17.14/dist/*" -d ./swagger-ui-5.17.14-dist \
     && rm -f swagger-ui-5.17.14.zip
 
-# Required by //project/crates-pro/crates_pro/src/main.rs
-RUN mkdir target
-
 ENV RUST_BACKTRACE=1
 
-# crates_pro image
+# 'crates_pro' image
 FROM base AS crates_pro
-COPY --from=builder /build/crates_pro ./crates_pro
-COPY --from=builder /build/.env ./.env
+COPY ./crates_pro ./crates_pro
+COPY ./.env ./.env
+# Required by //project/crates-pro/crates_pro/src/main.rs
+RUN mkdir target
 CMD ["./crates_pro"]
 
-# analyze image
+# 'analyze' image
 FROM base AS analyze
-COPY --from=builder /build/bin_analyze ./bin_analyze
-COPY --from=builder /build/.env ./.env
+COPY ./bin_analyze ./bin_analyze
+COPY ./.env ./.env
 CMD ["./bin_analyze"]
 
-# data_transport image
+# 'data_transport' image
 FROM base AS data_transport
-COPY --from=builder /build/bin_data_transport ./bin_data_transport
-COPY --from=builder /build/.env ./.env
+COPY ./bin_data_transport ./bin_data_transport
+COPY ./.env ./.env
 CMD ["./bin_data_transport"]
 
-# repo_import image
+# 'repo_import' image
 FROM base AS repo_import
-COPY --from=builder /build/bin_repo_import ./bin_repo_import
-COPY --from=builder /build/.env ./.env
+COPY ./bin_repo_import ./bin_repo_import
+COPY ./.env ./.env
 CMD ["./bin_repo_import"]

--- a/images/sensleak-worker.Dockerfile
+++ b/images/sensleak-worker.Dockerfile
@@ -1,0 +1,8 @@
+FROM almalinux:8.10-20250307 AS sensleak-worker
+
+COPY ./sensleak_worker ./sensleak_worker
+COPY ./scan ./scan
+COPY ./.env ./.env
+
+ENV RUST_BACKTRACE=1
+CMD ["./sensleak_worker"]

--- a/model/BUCK
+++ b/model/BUCK
@@ -7,7 +7,7 @@ rust_library(
         "src/tugraph_model.rs",
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//third-party:chrono",
         "//third-party:sea-orm",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "model"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/repo_import/BUCK
+++ b/repo_import/BUCK
@@ -9,7 +9,7 @@ rust_library(
         "src/version_info.rs",
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//project/crates-pro:model",
         "//third-party:bincode",

--- a/repo_import/Cargo.toml
+++ b/repo_import/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "repo_import"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/search/BUCK
+++ b/search/BUCK
@@ -8,7 +8,7 @@ rust_library(
         "src/search_prepare.rs"
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//third-party:pgvector",
         "//third-party:reqwest",

--- a/search/Cargo.toml
+++ b/search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "search"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 # third-party (第三方依赖, 不写具体版本号, 具体版本只在根目录 Cargo.toml 中出现)

--- a/sync_tool/Cargo.toml
+++ b/sync_tool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sync_tool"
 version = "0.0.1-alpha"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sync_tool/kafka_model/Cargo.toml
+++ b/sync_tool/kafka_model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kafka_model"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 entity = { path = "../storage/entity" }

--- a/sync_tool/storage/Cargo.toml
+++ b/sync_tool/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "storage"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sync_tool/storage/entity/Cargo.toml
+++ b/sync_tool/storage/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "entity"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/tudriver/BUCK
+++ b/tudriver/BUCK
@@ -5,7 +5,7 @@ rust_library(
         "src/tugraph_client.rs",
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//third-party:base64",
         "//third-party:neo4rs",

--- a/tudriver/Cargo.toml
+++ b/tudriver/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "tudriver"
 version = "0.1.0"
 

--- a/tuplugins/plugin1/BUCK
+++ b/tuplugins/plugin1/BUCK
@@ -19,7 +19,7 @@ rust_library(
     name = "plugin1",
     srcs = [":plugin1-0.1.0.crate"],
     crate_root = "plugin1-0.1.0.crate/src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = pkg_deps,
     rustc_flags = [
         "-Lnative=$(location //third-party:libtugraph-sys-build-script-run[out_dir])/build/output",

--- a/tuplugins/plugin1/Cargo.toml
+++ b/tuplugins/plugin1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plugin1"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tuplugins/plugin2/BUCK
+++ b/tuplugins/plugin2/BUCK
@@ -21,7 +21,7 @@ rust_library(
     name = "plugin2",
     srcs = [":plugin2-0.1.0.crate"],
     crate_root = "plugin2-0.1.0.crate/src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = pkg_deps,
     rustc_flags = [
         "-Lnative=$(location //third-party:libtugraph-sys-build-script-run[out_dir])/build/output",

--- a/tuplugins/plugin2/Cargo.toml
+++ b/tuplugins/plugin2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plugin2"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
* Fix ./deploy-crates-pro.sh deployment issues
* Add build target and deployment script for sensleak-worker
* Update to Rust 2024 edition