### PR TITLE
Switch the homepage version to all and create index for the tugraph database.

### DIFF
--- a/data_transporter/src/handler.rs
+++ b/data_transporter/src/handler.rs
@@ -157,7 +157,7 @@ pub struct SenseleakRes {
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct MircheckerRes {
     pub run_state: bool,
-    pub exist:bool,
+    pub exist: bool,
     pub res: String,
 }
 
@@ -826,7 +826,12 @@ pub async fn get_senseleak(nsfront: String, nsbehind: String) -> impl Responder 
     let return_val = SenseleakRes { exist, res };
     HttpResponse::Ok().json(return_val)
 }
-pub async fn get_mirchecker(nsfront: String, nsbehind: String,name:String,version:String) -> impl Responder {
+pub async fn get_mirchecker(
+    nsfront: String,
+    nsbehind: String,
+    name: String,
+    version: String,
+) -> impl Responder {
     let db_connection_config = db_connection_config_from_env();
     #[allow(unused_variables)]
     let (client, connection) = tokio_postgres::connect(&db_connection_config, NoTls)
@@ -838,14 +843,21 @@ pub async fn get_mirchecker(nsfront: String, nsbehind: String,name:String,versio
         }
     });
     let dbhandler = DBHandler { client };
-    let id = nsfront.clone() + "/" + &nsbehind +"/" + &name + "/" +&version;
-    let run_state = dbhandler.get_mirchecker_run_state_from_pg(id.clone()).await.unwrap();
+    let id = nsfront.clone() + "/" + &nsbehind + "/" + &name + "/" + &version;
+    let run_state = dbhandler
+        .get_mirchecker_run_state_from_pg(id.clone())
+        .await
+        .unwrap();
     let res = dbhandler.get_mirchecker_from_pg(id.clone()).await.unwrap();
     let mut exist = false;
-    if res.contains("warning: [MirChecker]"){
+    if res.contains("warning: [MirChecker]") {
         exist = true;
     }
-    let return_val = MircheckerRes { run_state,exist, res };
+    let return_val = MircheckerRes {
+        run_state,
+        exist,
+        res,
+    };
     HttpResponse::Ok().json(return_val)
 }
 

--- a/data_transporter/src/lib.rs
+++ b/data_transporter/src/lib.rs
@@ -283,7 +283,7 @@ pub async fn run_api_server() -> std::io::Result<()> {
     .await
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema,Hash,PartialEq,Eq)]
 pub struct NameVersion {
     pub name: String,
     pub version: String,


### PR DESCRIPTION
We changed the version of the homepage that is clicked after searching for a crate from the original latest version to the all version. After the change, the homepage shows the direct and indirect dependencies of all versions of the crate, as well as the direct CVE and indirect CVE of all versions. At the same time, for issues such as slow access to the version interface, we tested the time required to connect to and query the tugraph database in the code, and found that the root cause of the slow access to the version interface is the slow query of the database. Therefore, we indexed the data we need to query in the database, avoiding the full table scan during the original query, greatly improving the query performance, and shortening the single query time from the original 300ms to 3-4ms.